### PR TITLE
Add basic smoke test for App

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,13 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
+      "^react-router$": "<rootDir>/node_modules/react-router/dist/development/index.js",
+      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+// Mock Firebase modules to avoid initialization errors in tests
+jest.mock('./firebase/config', () => ({ auth: {}, db: {} }));
+jest.mock('./firebase/auth', () => ({
+  login: jest.fn(),
+  register: jest.fn(),
+  logout: jest.fn(),
+}));
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Endgame Trainer heading', () => {
+  // Navigate to the trainer route so the heading is visible
+  window.history.pushState({}, 'Trainer page', '/trainer');
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /Endgame Trainer/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,25 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill TextEncoder/TextDecoder for environments like Jest
+import { TextEncoder, TextDecoder } from 'util';
+if (!global.TextEncoder) {
+  // @ts-ignore
+  global.TextEncoder = TextEncoder;
+}
+if (!global.TextDecoder) {
+  // @ts-ignore
+  global.TextDecoder = TextDecoder;
+}
+
+// Basic stub for ResizeObserver used by react-chessboard in tests
+if (typeof (global as any).ResizeObserver === 'undefined') {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  (global as any).ResizeObserver = ResizeObserver;
+}


### PR DESCRIPTION
## Summary
- add jest moduleNameMapper overrides for react-router to support tests
- mock Firebase modules and check Trainer heading in `App.test.tsx`
- polyfill TextEncoder and ResizeObserver in test setup

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6876151e97888329bdac5b327744a702