### PR TITLE
Fix measurement env var in Firebase config

### DIFF
--- a/src/firebase/config.ts
+++ b/src/firebase/config.ts
@@ -11,7 +11,7 @@ const firebaseConfig = {
   storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET!,
   messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID!,
   appId: process.env.REACT_APP_FIREBASE_APP_ID!,
-  measurementId: process.env.EACT_APP_FIREBASE_MEASUREMENT_ID!,
+  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID!,
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- correct Firebase analytics environment variable name

## Testing
- `node -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6876151a1e148329bc667cbd503ceef5