### PR TITLE
Integrate Stockfish evaluation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.3",
         "react-scripts": "5.0.1",
+        "stockfish": "^16.0.0",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       }
@@ -16260,6 +16261,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stockfish": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/stockfish/-/stockfish-16.0.0.tgz",
+      "integrity": "sha512-uu4AqsE2x0tD+SsYzZy4UtqeH4U9zDi1V8loDFDbMwCtvumGXF9j81Pg1ZmIkUgZhwQqPxQAv8IN5oy6hZa7Bw==",
+      "license": "GPL",
+      "bin": {
+        "stockfishjs": "stockfishjs"
       }
     },
     "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
     "react-scripts": "5.0.1",
+    "stockfish": "^16.0.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,6 +8,7 @@ jest.mock('./firebase/auth', () => ({
   register: jest.fn(),
   logout: jest.fn(),
 }));
+jest.mock('stockfish');
 
 import App from './App';
 

--- a/src/__mocks__/stockfish.ts
+++ b/src/__mocks__/stockfish.ts
@@ -1,0 +1,6 @@
+export default function Stockfish() {
+  return {
+    postMessage: () => {},
+    onmessage: null,
+  } as unknown as Worker;
+}

--- a/src/pages/Trainer.tsx
+++ b/src/pages/Trainer.tsx
@@ -1,16 +1,41 @@
 import { useState, useEffect } from 'react';
 import { Chessboard, ChessboardOptions } from 'react-chessboard';
 import { Chess } from 'chess.js';
+import Stockfish from 'stockfish';
 
 export default function Trainer() {
   const startingFEN = '8/8/8/8/4k3/8/4P3/4K3 w - - 0 1';
 
   const [game, setGame] = useState<Chess | null>(null);
   const [fen, setFen] = useState(startingFEN);
+  const [evalInfo, setEvalInfo] = useState('');
+  const [engine, setEngine] = useState<Worker | null>(null);
 
   useEffect(() => {
     const initialGame = new Chess(startingFEN);
     setGame(initialGame);
+    const sf = Stockfish();
+    const handleMessage = (event: MessageEvent | string) => {
+      const line = typeof event === 'string' ? event : event.data;
+      if (typeof line !== 'string') return;
+      const bestMatch = line.match(/^bestmove (\S+)/);
+      if (bestMatch) {
+        setEvalInfo((prev) => `${prev}\nBest move: ${bestMatch[1]}`);
+        return;
+      }
+      const evalMatch = line.match(/score cp (-?\d+)/);
+      if (evalMatch) {
+        const score = parseInt(evalMatch[1], 10);
+        setEvalInfo(`Evaluation: ${score} cp`);
+      }
+    };
+    sf.onmessage = handleMessage;
+    sf.postMessage('uci');
+    setEngine(sf as unknown as Worker);
+    evaluatePosition(startingFEN);
+    return () => {
+      (sf as any).terminate?.();
+    };
   }, []);
 
   function makeMove(move: { from: string; to: string; promotion?: string }) {
@@ -20,6 +45,7 @@ export default function Trainer() {
     if (result) {
       setGame(newGame);
       setFen(newGame.fen());
+      evaluatePosition(newGame.fen());
     }
     return result;
   }
@@ -27,6 +53,13 @@ export default function Trainer() {
   function handleDrop({ sourceSquare, targetSquare }: { sourceSquare: string; targetSquare: string | null }) {
     const moveMade = makeMove({ from: sourceSquare, to: targetSquare || '', promotion: 'q' });
     return moveMade !== null;
+  }
+
+  function evaluatePosition(currentFen: string) {
+    if (!engine) return;
+    setEvalInfo('Evaluating...');
+    engine.postMessage(`position fen ${currentFen}`);
+    engine.postMessage('go depth 12');
   }
 
   const boardOptions: ChessboardOptions = {
@@ -40,6 +73,7 @@ export default function Trainer() {
     <div style={{ padding: 32 }}>
       <h2>Endgame Trainer</h2>
       {game && <Chessboard options={boardOptions} />}
+      <pre>{evalInfo}</pre>
     </div>
   );
 }

--- a/src/types/stockfish.d.ts
+++ b/src/types/stockfish.d.ts
@@ -1,0 +1,1 @@
+declare module 'stockfish';


### PR DESCRIPTION
## Summary
- install Stockfish engine
- provide TypeScript definition stub
- mock Stockfish for tests
- evaluate board positions with Stockfish after each move
- display engine evaluation and best move in trainer page

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_687668b24bb8832981ed382fe89525c3